### PR TITLE
#691 detailed post search in mobile app implemented.

### DIFF
--- a/ludos/mobile/lib/detailed_post_search.dart
+++ b/ludos/mobile/lib/detailed_post_search.dart
@@ -4,41 +4,44 @@ import 'package:ludos_mobile_app/userProvider.dart';
 import 'helper/colors.dart';
 import 'search_page_game.dart';
 import 'search_page_user.dart';
+import 'search_page_post.dart';
 
-
-class DetailedGameSearch extends StatefulWidget {
+class DetailedPostSearch extends StatefulWidget {
   final UserProvider userProvider;
-  final String? initialSearchKey; // Pass an initial search key if available
+  final String? initialSearchKey;
 
-  const DetailedGameSearch({
+  const DetailedPostSearch({
     Key? key,
     required this.userProvider,
     this.initialSearchKey,
   }) : super(key: key);
 
   @override
-  State<DetailedGameSearch> createState() => _DetailedGameSearchState();
+  State<DetailedPostSearch> createState() => _DetailedPostSearchState();
 }
 
-class _DetailedGameSearchState extends State<DetailedGameSearch> {
+class _DetailedPostSearchState extends State<DetailedPostSearch> {
   final TextEditingController searchInputController = TextEditingController();
   final TextEditingController tagsController = TextEditingController();
-  final TextEditingController platformsController = TextEditingController();
-  final TextEditingController publisherController = TextEditingController();
+  final TextEditingController gameIDController = TextEditingController();
+  final TextEditingController groupIDController = TextEditingController();
+  final TextEditingController ownerUserIDController = TextEditingController();
   final TextEditingController developerController = TextEditingController();
 
   int page_number = 1;
   bool showResult = false;
-  bool isFollowed = false;
-  bool orderByFollowers = false;
-  bool orderByRatings = false;
+  bool isLiked = false;
+  bool isDisliked = false;
+  bool orderByLikes = false;
   bool order = false;
   String searchText = '';
   String tags = '';
-  String platforms = '';
+  String groupID = '';
+  String gameTitle = '';
+  String ownerUserID = '';
   String? criteria = '';
 
-  Key searchGameKey = UniqueKey();
+  Key searchPostKey = UniqueKey();
 
   @override
   void initState() {
@@ -46,23 +49,24 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
     super.initState();
   }
 
-    void updateCriteria(){
-      setState((){
-        if (orderByFollowers == true){
-          criteria = 'followers';
-        }
-        else if (orderByRatings == true){
-          criteria = 'ratings';
-        }
-        else {
-          criteria = '';
-        }
-      });
-    }
-
   void updateShowState() {
     setState(() {
-      showResult = (searchText.toString() != '' || tags.toString() != '');
+      showResult = (searchText.toString() != '' ||
+          tags.toString() != '' ||
+          gameTitle.toString() != '' ||
+          groupID.toString() != '' ||
+          ownerUserID.toString() != ''
+      );
+    });
+  }
+
+  void updateCriteria(){
+    setState((){
+      if (orderByLikes == true){
+        criteria = 'numberOfLikes';
+      }else{
+        criteria = 'createdAt';
+      }
     });
   }
 
@@ -73,7 +77,7 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
       appBar: AppBar(
         backgroundColor: const Color(0xFFf89c34),
         title: const Text(
-          'Search Games',
+          'Search Posts',
           style: TextStyle(
             color: MyColors.white,
             fontSize: 20,
@@ -84,7 +88,6 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
         child: Column(
           children: [
             const SizedBox(height: 20),
-            // Search key field
             Center(
               child: Padding(
                 padding: const EdgeInsets.all(10.0),
@@ -97,10 +100,9 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
                   ),
                   obscureText: false,
                   decoration: InputDecoration(
-                    hintText: 'Search by title',
+                    hintText: 'Search by title or body',
                     filled: true,
                     fillColor: MyColors.blue2,
-                    //labelText: 'Search',
                     labelStyle: const TextStyle(
                         color: MyColors.darkBlue,
                         fontWeight: FontWeight.bold),
@@ -108,7 +110,6 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
                         borderSide: BorderSide(
                             color: MyColors.red, width: 2.0)
                     ),
-
                     focusedBorder: const UnderlineInputBorder(
                       borderSide: BorderSide(color: MyColors.red, width: 2.0),
                     ),
@@ -116,11 +117,9 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
                       borderSide: BorderSide(color: MyColors.red, width: 3.0),
                       borderRadius: BorderRadius.all(Radius.circular(12.0)),
                     ),
-                    //floatingLabelBehavior: (searchText.toString() != '') ? FloatingLabelBehavior.never : FloatingLabelBehavior.always,
                   ),
                   cursorColor: MyColors.lightBlue,
                 ),
-
               ),
             ),
             const SizedBox(height: 10),
@@ -148,7 +147,6 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
                         borderSide: BorderSide(
                             color: MyColors.red, width: 2.0)
                     ),
-
                     focusedBorder: const UnderlineInputBorder(
                       borderSide: BorderSide(color: MyColors.red, width: 2.0),
                     ),
@@ -167,7 +165,7 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
               child: Padding(
                 padding: const EdgeInsets.all(10.0),
                 child: TextFormField(
-                  controller: platformsController,
+                  controller: gameIDController,
                   style: const TextStyle(
                       color: Colors.black,
                       fontWeight: FontWeight.bold,
@@ -175,7 +173,7 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
                   ),
                   obscureText: false,
                   decoration: InputDecoration(
-                    hintText: 'Search by comma separated platforms',
+                    hintText: 'Search by game title that post belongs to',
                     filled: true,
                     fillColor: MyColors.blue2,
                     //labelText: 'Search',
@@ -186,7 +184,6 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
                         borderSide: BorderSide(
                             color: MyColors.red, width: 2.0)
                     ),
-
                     focusedBorder: const UnderlineInputBorder(
                       borderSide: BorderSide(color: MyColors.red, width: 2.0),
                     ),
@@ -200,67 +197,161 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
               ),
             ),
             const SizedBox(height: 10),
+            Center(
+              child: Padding(
+                padding: const EdgeInsets.all(10.0),
+                child: TextFormField(
+                  controller: ownerUserIDController,
+                  style: const TextStyle(
+                      color: Colors.black,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 18
+                  ),
+                  obscureText: false,
+                  decoration: InputDecoration(
+                    hintText: 'Search by owner id that post belongs to',
+                    filled: true,
+                    fillColor: MyColors.blue2,
+                    labelStyle: const TextStyle(
+                        color: MyColors.darkBlue,
+                        fontWeight: FontWeight.bold),
+                    border: const OutlineInputBorder(
+                        borderSide: BorderSide(
+                            color: MyColors.red, width: 2.0)
+                    ),
+                    focusedBorder: const UnderlineInputBorder(
+                      borderSide: BorderSide(color: MyColors.red, width: 2.0),
+                    ),
+                    enabledBorder: const OutlineInputBorder(
+                      borderSide: BorderSide(color: MyColors.red, width: 3.0),
+                      borderRadius: BorderRadius.all(Radius.circular(12.0)),
+                    ),
+                  ),
+                  cursorColor: MyColors.lightBlue,
+                ),
+              ),
+            ),
+            // checkboxes
+            const SizedBox(height: 10),
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: [
                 const SizedBox(width: 10),
                 Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text(
-                      'List only',
-                      style: TextStyle(
-                        color: MyColors.white,
-                        fontSize: 18,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        'List only',
+                        style: TextStyle(
+                          color: MyColors.white,
+                          fontSize: 18,
+                        ),
                       ),
-                    ),
-                    Text(
-                      'followed',
-                      style: TextStyle(
-                        color: MyColors.white,
-                        fontSize: 18,
+                      Text(
+                        'liked',
+                        style: TextStyle(
+                          color: MyColors.white,
+                          fontSize: 18,
+                        ),
                       ),
-                    ),
-                    Text(
-                      'games',
-                      style: TextStyle(
-                        color: MyColors.white,
-                        fontSize: 18,
+                      Text(
+                        'posts',
+                        style: TextStyle(
+                          color: MyColors.white,
+                          fontSize: 18,
+                        ),
                       ),
-                    ),
 
-                    Checkbox(
-                      value: isFollowed,
-                      overlayColor: MaterialStateProperty.all(MyColors.lightBlue),
-                      side: const BorderSide(color: MyColors.lightBlue),
-                      activeColor: MyColors.green,
-
-                      onChanged: (value) {
-                        setState(() {
-                          if(widget.userProvider.username == ''){
-                            SnackBar snackBar = SnackBar(
-                              content: Text('You must be logged in to use this feature'),
-                              backgroundColor: MyColors.red,
-                            );
-                            ScaffoldMessenger.of(context).showSnackBar(snackBar);
-                          }
-                          else{
-                            isFollowed = value!;
-                            //searchGameKey = UniqueKey();
-                          }
-
-                        });
-                      },
-                    ),
-                  ]
-                ),
-                const SizedBox(width: 10),
-                VerticalDivider(
-                  color: MyColors.red,
-                  thickness: 20,
+                      Checkbox(
+                        value: isLiked,
+                        overlayColor: MaterialStateProperty.all(MyColors.lightBlue),
+                        side: BorderSide(color: isDisliked ? MyColors.red : MyColors.lightBlue),
+                        activeColor: MyColors.green,
+                        onChanged: (value) {
+                          setState(() {
+                            if(widget.userProvider.username == ''){
+                              SnackBar snackBar = SnackBar(
+                                content: Text('You must be logged in to use this feature'),
+                                backgroundColor: MyColors.red,
+                              );
+                              ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                            }
+                            else{
+                              if (isDisliked == true){
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(
+                                      content: Text('You cannot select both liked and disliked'),
+                                      backgroundColor: MyColors.red,
+                                    )
+                                );
+                            }
+                              else{
+                                isLiked = value!;
+                              }
+                            }
+                          });
+                        },
+                      ),
+                    ]
                 ),
                 Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        'List only',
+                        style: TextStyle(
+                          color: MyColors.white,
+                          fontSize: 18,
+                        ),
+                      ),
+                      Text(
+                        'disliked',
+                        style: TextStyle(
+                          color: MyColors.white,
+                          fontSize: 18,
+                        ),
+                      ),
+                      Text(
+                        'posts',
+                        style: TextStyle(
+                          color: MyColors.white,
+                          fontSize: 18,
+                        ),
+                      ),
+                      Checkbox(
+                        value: isDisliked,
+                        overlayColor: MaterialStateProperty.all(MyColors.lightBlue),
+                        side: BorderSide(color: isLiked ? MyColors.red : MyColors.lightBlue),
+                        activeColor: MyColors.green,
+                        onChanged: (value) {
+                          setState(() {
+                            if(widget.userProvider.username == ''){
+                              SnackBar snackBar = SnackBar(
+                                content: Text('You must be logged in to use this feature'),
+                                backgroundColor: MyColors.red,
+                              );
+                              ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                            }
+                            else{
+                              if (isLiked == true){
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(
+                                      content: Text('You cannot select both liked and disliked'),
+                                      backgroundColor: MyColors.red,
+                                    )
+                                );
+                              }else{
+                                isDisliked = value!;
+                              }
+                              //searchGameKey = UniqueKey();
+                            }
+                          });
+                        },
+                      ),
+                    ]
+                ),
+                Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Text('Order by', style: TextStyle(
                         color: MyColors.white,
@@ -270,66 +361,18 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
                         color: MyColors.white,
                         fontSize: 18,
                       )),
-                      Text('followers', style: TextStyle(
+                      Text('likes', style: TextStyle(
                         color: MyColors.white,
                         fontSize: 18,
                       )),
                       Checkbox(
-                        value: orderByFollowers,
+                        value: orderByLikes,
                         overlayColor: MaterialStateProperty.all(MyColors.lightBlue),
-                        side: BorderSide(color: orderByRatings ? MyColors.red : MyColors.lightBlue),
+                        side: const BorderSide(color: MyColors.lightBlue),
                         activeColor: MyColors.green,
-
                         onChanged: (value) {
                           setState(() {
-                            if (orderByRatings == true) {
-                              SnackBar snackBar = SnackBar(
-                                content: Text('You can only order by one criteria'),
-                                backgroundColor: MyColors.red,
-                              );
-                              ScaffoldMessenger.of(context).showSnackBar(snackBar);
-                            }
-                            orderByFollowers = orderByRatings ? orderByFollowers : value!;
-                            updateCriteria();
-                            //searchGameKey = UniqueKey();
-                          });
-                        },
-                      ),
-                    ]
-                ),
-                const SizedBox(width: 10),
-                Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text('Order', style: TextStyle(
-                        color: MyColors.white,
-                        fontSize: 18,
-                      )),
-                      Text('by', style: TextStyle(
-                        color: MyColors.white,
-                        fontSize: 18,
-                      )),
-                      Text('ratings', style: TextStyle(
-                        color: MyColors.white,
-                        fontSize: 18,
-                      )),
-                      Checkbox(
-                        value: orderByRatings,
-                        overlayColor: MaterialStateProperty.all(MyColors.lightBlue),
-                        side: BorderSide(color: orderByFollowers ? MyColors.red : MyColors.lightBlue),
-                        activeColor: MyColors.green,
-
-                        onChanged: (value) {
-                          setState(() {
-                            if (orderByFollowers == true) {
-
-                              SnackBar snackBar = SnackBar(
-                                content: Text('You can only order by one criteria'),
-                                backgroundColor: MyColors.red,
-                              );
-                              ScaffoldMessenger.of(context).showSnackBar(snackBar);
-                            }
-                            orderByRatings = orderByFollowers ? orderByRatings : value!;
+                            orderByLikes = value!;
                             updateCriteria();
                             //searchGameKey = UniqueKey();
                           });
@@ -379,16 +422,18 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
                 ),
               ],
             ),
-
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: () {
                 setState(() {
                   searchText = searchInputController.text;
                   tags = tagsController.text;
-                  platforms = platformsController.text;
+                  gameTitle = gameIDController.text;
+                  groupID = groupIDController.text;
+                  ownerUserID = ownerUserIDController.text;
+                  updateCriteria();
                   updateShowState();
-                  searchGameKey = UniqueKey();
+                  searchPostKey = UniqueKey();
                 });
               },
               style: ElevatedButton.styleFrom(
@@ -415,8 +460,7 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
             SingleChildScrollView(
                 child: Column(
                   children: [
-                    //if (showResult == true)
-                    if (true)
+                    if (showResult == true)
                       Column(
                         children: [
                           const SizedBox(height: 10),
@@ -425,7 +469,7 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
                             children: [
                               SizedBox(width: 20),
                               Text(
-                                'Games',
+                                'Posts',
                                 style: TextStyle(
                                   color: MyColors.lightBlue,
                                   fontSize: 18,
@@ -433,16 +477,17 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
                               ),
                             ],
                           ),
-
-                          SearchPageGame(
-                            key: searchGameKey,
+                          SearchPagePost(
+                            page: page_number,
+                            key: searchPostKey,
                             searchKey: searchText,
                             tags: tags,
-                            platforms: platforms,
-                            isFollowed: isFollowed,
-                            order : order ? 'DESC' : 'ASC',
-                            page: page_number,
                             criteria: criteria,
+                            isLiked: isLiked,
+                            isDisliked: isDisliked,
+                            order : order ? 'DESC' : 'ASC',
+                            gameTitle: gameTitle,
+                            owner: ownerUserID,
                             userProvider: widget.userProvider,
                             token: widget.userProvider.token,
                           ),
@@ -461,66 +506,66 @@ class _DetailedGameSearchState extends State<DetailedGameSearch> {
                           ),
                           const SizedBox(height: 20),
                           Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              ElevatedButton(
-                                onPressed: () {
-                                  setState(() {
-                                    if (page_number > 1){
-                                      page_number -= 1;
-                                      searchGameKey = UniqueKey();
-                                    }
-                                  });
-                                },
-                                style: ElevatedButton.styleFrom(
-                                  primary: MyColors.lightBlue, // Change the background color as needed
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(12), // Optional: adjust the border radius
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                ElevatedButton(
+                                  onPressed: () {
+                                    setState(() {
+                                      if (page_number > 1){
+                                        page_number -= 1;
+                                        searchPostKey = UniqueKey();
+                                      }
+                                    });
+                                  },
+                                  style: ElevatedButton.styleFrom(
+                                    primary: MyColors.lightBlue, // Change the background color as needed
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(12), // Optional: adjust the border radius
+                                    ),
+                                  ),
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(10.0),
+                                    child: Row(
+                                      mainAxisAlignment: MainAxisAlignment.center,
+                                      children: [
+                                        Icon(
+                                          Icons.arrow_back,
+                                          color: Colors.black, // Change the icon color as needed
+                                          size: 25.0, // Adjust the icon size as needed
+                                        ),
+                                      ],
+                                    ),
                                   ),
                                 ),
-                                child: Padding(
-                                  padding: const EdgeInsets.all(10.0),
-                                  child: Row(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      Icon(
-                                        Icons.arrow_back,
-                                        color: Colors.black, // Change the icon color as needed
-                                        size: 25.0, // Adjust the icon size as needed
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                              ),
-                              const SizedBox(width: 20),
-                              ElevatedButton(
-                                onPressed: () {
-                                  setState(() {
+                                const SizedBox(width: 20),
+                                ElevatedButton(
+                                  onPressed: () {
+                                    setState(() {
                                       page_number += 1;
-                                      searchGameKey = UniqueKey();
-                                  });
-                                },
-                                style: ElevatedButton.styleFrom(
-                                  primary: MyColors.lightBlue, // Change the background color as needed
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(12), // Optional: adjust the border radius
+                                      searchPostKey = UniqueKey();
+                                    });
+                                  },
+                                  style: ElevatedButton.styleFrom(
+                                    primary: MyColors.lightBlue, // Change the background color as needed
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(12), // Optional: adjust the border radius
+                                    ),
+                                  ),
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(10.0),
+                                    child: Row(
+                                      mainAxisAlignment: MainAxisAlignment.center,
+                                      children: [
+                                        Icon(
+                                          Icons.arrow_forward,
+                                          color: Colors.black, // Change the icon color as needed
+                                          size: 25.0, // Adjust the icon size as needed
+                                        ),
+                                      ],
+                                    ),
                                   ),
                                 ),
-                                child: Padding(
-                                  padding: const EdgeInsets.all(10.0),
-                                  child: Row(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      Icon(
-                                        Icons.arrow_forward,
-                                        color: Colors.black, // Change the icon color as needed
-                                        size: 25.0, // Adjust the icon size as needed
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                              ),
-                            ]
+                              ]
                           ),
                           const SizedBox(height: 20),
                         ],

--- a/ludos/mobile/lib/helper/APIService.dart
+++ b/ludos/mobile/lib/helper/APIService.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:ludos_mobile_app/helper/EntityContent.dart';
 
@@ -176,9 +177,6 @@ class APIService {
       'isFollowed': isFollowed.toString(),
       'orderByKey': orderByKey,
     };
-
-    print("orderby: $orderByKey");
-    print("order: $order");
 
     // Add optional parameters if provided
     if (searchKey != null) queryParams['searchKey'] = searchKey;
@@ -387,6 +385,98 @@ class APIService {
     });
 
     return response;
+  }
+
+  Future<http.Response> listPosts(String? authToken,
+      {int page = 1,
+        int limit = 10,
+        String? searchKey,
+        String? tags,
+        List<String> gameId = const [],
+        String? groupId,
+        String? ownerUserId,
+        bool isLiked = false,
+        bool isDisliked = false,
+        String order = "DESC",
+        String orderByKey = "createdAt"}) async {
+
+    // Create a list to store individual responses
+    List<http.Response> individualResponses = [];
+
+    for (int i = 0; i < gameId.length; i++) {
+      // Create a map to store query parameters for each gameId
+      final Map<String, String> queryParams = {
+        'page': page.toString(),
+        'limit': limit.toString(),
+        'order': order,
+        'isLiked': isLiked.toString(),
+        'isDisliked': isDisliked.toString(),
+        'orderByKey': orderByKey,
+        'gameId': gameId[i],
+      };
+
+      // Add optional parameters if provided
+      if (searchKey != null) queryParams['searchKey'] = searchKey;
+      if (tags != null) queryParams['tags'] = tags;
+      if (groupId != null) queryParams['groupId'] = groupId;
+      if (ownerUserId != null) queryParams['ownerUserId'] = ownerUserId;
+
+      // Create the URI with query parameters
+      var uri = Uri.parse("$baseURL/post").replace(queryParameters: queryParams);
+
+      // Make the HTTP request for each gameId
+      var res = await http.get(uri, headers: {
+        'content-type': 'application/json',
+        'Authorization': 'Bearer $authToken',
+        HttpHeaders.contentTypeHeader: 'application/json; charset=utf-8',
+      });
+
+      if (res.statusCode == 200) {
+        // Add individual response to the list
+        print("Individual Response: ${res.body}");
+        individualResponses.add(res);
+      } else {
+        throw Exception('Failed to load threads');
+      }
+    }
+
+    // Combine individual responses into a single response
+    http.Response combinedResponse = combineResponses(individualResponses);
+
+    print("Combined Response: ${combinedResponse.body}");
+    return combinedResponse;
+  }
+
+  http.Response combineResponses(List<http.Response> responses) {
+    // Initialize an empty list to store combined items
+    List<dynamic> combinedItems = [];
+
+    // Iterate through each response
+    for (var response in responses) {
+      // Parse the response body
+      Map<String, dynamic> responseBody = json.decode(utf8.decode(response.bodyBytes, allowMalformed: true));
+
+      // Extract the "items" array from the response
+      List<dynamic> items = responseBody['items'];
+
+      // Add the items to the combined list
+      combinedItems.addAll(items);
+
+      // Add the items to the combined list
+    }
+
+    // Create a combined response with the merged "items" list
+    Map<String, dynamic> combinedResponseBody = {'items': combinedItems};
+
+    String combinedResponseString = json.encode(combinedResponseBody);
+    //print("Combined Response String: $combinedResponseString");
+    // Create an HTTP response with the combined body
+    http.Response combinedResponse = http.Response(combinedResponseString, 200,
+        headers: {
+          HttpHeaders.contentTypeHeader: 'application/json; charset=utf-8',
+        });
+
+    return combinedResponse;
   }
 
   Future<http.Response> search(String? authToken, String searchKey) async {

--- a/ludos/mobile/lib/search_landing_page.dart
+++ b/ludos/mobile/lib/search_landing_page.dart
@@ -6,6 +6,7 @@ import 'search_page_game.dart';
 import 'search_page_user.dart';
 import 'search_page.dart';
 import 'detailed_game_search.dart';
+import 'detailed_post_search.dart';
 
 class SearchLandingPage extends StatelessWidget {
   final UserProvider userProvider;
@@ -92,7 +93,9 @@ class SearchLandingPage extends StatelessWidget {
                     ),
                     onPressed: () {
                       Navigator.of(context).push(MaterialPageRoute(
-                        builder: (context) => SearchPage(userProvider: userProvider),
+                        builder: (context) => DetailedPostSearch(
+                          userProvider: userProvider
+                        ),
                       ));
                     },
                     child: Container(

--- a/ludos/mobile/lib/search_page_game.dart
+++ b/ludos/mobile/lib/search_page_game.dart
@@ -70,8 +70,6 @@ class _SearchPageGameState extends State<SearchPageGame> {
         orderByKey: widget.criteria ?? '',
         tags: widget.tags ?? '');
     try {
-      print("criteria: ${widget.criteria}");
-      //print(json.decode(response.body));
       if (response.statusCode == 200) {
         print("Success: ${response.statusCode} - ${response.body}");
         final Map<String, dynamic> responseData = json.decode(response.body);

--- a/ludos/mobile/lib/search_page_post.dart
+++ b/ludos/mobile/lib/search_page_post.dart
@@ -1,0 +1,255 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:ludos_mobile_app/reusable_widgets/custom_widgets.dart';
+import 'package:ludos_mobile_app/userProvider.dart';
+import 'helper/colors.dart';
+import 'login_page.dart';
+import 'main.dart';
+//import 'reusable_widgets/game_summary.dart';
+import 'reusable_widgets/forum_thread.dart';
+import 'helper/APIService.dart';
+import 'create_game.dart';
+import 'reusable_widgets/custom_navigation_bar.dart';
+
+class SearchPagePost extends StatefulWidget {
+  final int page;
+  final String? order;
+  final String? owner;
+  final String? searchKey;
+  final String? gameTitle;
+  final String? tags;
+  final String? token;
+  final String? criteria;
+  final bool? isLiked;
+  final bool? isDisliked;
+  //final String? groupId;
+  final UserProvider userProvider;
+
+  const SearchPagePost({
+    Key? key,
+    required this.page,
+    required this.token,
+    this.order,
+    this.gameTitle,
+    this.owner,
+    this.searchKey,
+    this.tags,
+    this.criteria,
+    this.isLiked,
+    this.isDisliked,
+    //this.groupId,
+    required this.userProvider})
+      : super(key: key);
+
+  @override
+  State<SearchPagePost> createState() => _SearchPagePostState();
+}
+
+class _SearchPagePostState extends State<SearchPagePost> {
+  late int size = 0;
+  List<String> gameID = [];
+  late Future<List<ThreadSummary>> threads = Future.value([]);
+
+  @override
+  void initState() {
+    super.initState();
+    initializeData();
+  }
+
+  Future<void> initializeData() async {
+    await fetchGameID(widget.token, widget.gameTitle!);
+    threads = fetchData(widget.token);
+    setState(() {
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant SearchPagePost oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.searchKey != oldWidget.searchKey) {
+      // Trigger a new data fetch when searchKey changes
+      threads = fetchData(widget.token);
+    }
+  }
+
+  Future<void> fetchGameID(String? token, String gameTitle) async {
+    try {
+      final response = await APIService().listGames(
+        widget.userProvider.token,
+        searchKey: gameTitle,
+      );
+
+      if (response.statusCode == 200) {
+        final Map<String, dynamic> responseData = json.decode(response.body);
+
+        // Check if 'items' key exists in the response data
+        if (responseData.containsKey('items')) {
+          List<dynamic>? gamesList = responseData['items'];
+
+          // Check if gamesList is not null and not empty
+          if (gamesList != null && gamesList.isNotEmpty) {
+            setState(() {
+              for (int i = 0; i < gamesList.length; i++) {
+                gameID.add(gamesList[i]['id'].toString());
+              }
+            });
+          } else {
+            throw Exception('No games found with the given title');
+          }
+        } else {
+          throw Exception('Invalid response format: Missing "items" key');
+        }
+      } else {
+        print("Error: ${response.statusCode} - ${response.body}");
+        throw Exception('Failed to load games');
+      }
+    } catch (error) {
+      print("Error: $error");
+      throw Exception('Failed to load games');
+    }
+  }
+
+
+  Future<List<ThreadSummary>> fetchData(String? token) async {
+    // final response = await APIService().listThreadsBySearch(searchText, widget.gameid, widget.token);
+    final response = await APIService().listPosts(
+      widget.userProvider.token,
+      page: widget.page,
+      searchKey: widget.searchKey ?? '',
+      tags: widget.tags ?? '',
+      order: widget.order ?? '',
+      orderByKey: widget.criteria ?? '',
+      isLiked: widget.isLiked ?? false,
+      isDisliked: widget.isDisliked ?? false,
+      //groupId: widget.groupId ?? '',
+      ownerUserId: widget.owner ?? '',
+      gameId: (widget.gameTitle != null) ? gameID : const [],
+    );
+    try {
+      if (response.statusCode == 200) {
+        print("Response: ${response.body}");
+        final String responseData = response.body;
+        print("Response Data: $responseData");
+
+        List<dynamic> postLists = json.decode(responseData)['items'];
+        print("Post Lists: $postLists");
+        return postLists.map((dynamic item) => ThreadSummary(
+          token: widget.token,
+          userProvider: widget.userProvider,
+          threadId: item['id'],
+          title: item['title'],
+          game: item['game']['title'],
+          gameId: item['game']['id'],
+          userId: item['user']['id'],
+          username: item['user']['username'],
+          thumbUps: item['numberOfLikes'],
+          thumbDowns: item['NumberOfDislikes'],
+          time: item['createdAt'],
+          isLiked: (item['isLiked'] ?? false),
+          isDisliked: (item['isDisliked'] ?? false),
+          textColor: MyColors.white,
+          backgroundColor: MyColors.blue,
+          fontSize: 20,
+        )).toList();
+      } else {
+        print("Error: ${response.statusCode} - ${response.body}");
+        throw Exception('Failed to load posts');
+      }
+    } catch (error) {
+      print("Error: $error");
+      throw Exception('Failed to load threads!');
+    }
+  }
+
+  /*
+  Future<List<GameSummary>> fetchData(String? token) async {
+    //final response = await APIService().listSearchedGames(widget.userProvider.token, widget.searchKey);
+    //final response = await APIService().search(widget.userProvider.token, widget.searchKey!);
+    final response = await APIService().listGames(
+        widget.userProvider.token,
+        page: widget.page,
+        order: widget.order ?? '',
+        searchKey: widget.searchKey ?? '',
+        platforms: widget.platforms ?? '',
+        isFollowed: widget.isFollowed,
+        orderByKey: widget.criteria ?? '',
+        tags: widget.tags ?? '');
+    try {
+      if (response.statusCode == 200) {
+        final Map<String, dynamic> responseData = json.decode(response.body);
+
+        List<dynamic> gamesList = responseData['items'];
+        setState(() {
+          size = gamesList.length;
+        });
+        return gamesList
+            .map((dynamic item) => GameSummary(
+            title: item['title'],
+            averageRating: (item['averageRating'] == null
+                ? 0
+                : item['averageRating'].toDouble()),
+            coverLink: item['coverLink'],
+            numOfFollowers: item['followers'],
+            gameStory: item['gameStory'],
+            tags: item['tags'],
+            textColor: MyColors.white,
+            backgroundColor: MyColors.blue,
+            fontSize: 20,
+            id: item['id'],
+            token: widget.token,
+            userProvider: widget.userProvider))
+            .toList();
+      } else {
+        print("Error: ${response.statusCode} - ${response.body}");
+        throw Exception('Failed to load games');
+      }
+    } catch (error) {
+      print("Error: $error");
+      throw Exception('Failed to load games');
+    }
+  }
+*/
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const SizedBox(height: 15),
+          //const SafeArea(child: SizedBox(height: 10)),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: FutureBuilder<List<ThreadSummary>>(
+              future: threads,
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  // Show a loading indicator while fetching data
+                  return const Center(child: CircularProgressIndicator());
+                } else if (snapshot.hasError) {
+                  // Handle errors
+                  return Center(child: Text('Error: ${snapshot.error}'));
+                } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                  // Handle the case when there is no data
+                  return const Center(
+                      child: Text('No post found',
+                          style: TextStyle(color: MyColors.orange,
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold)));
+                } else {
+                  // Display the fetched data
+                  return Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: snapshot.data!,
+                  );
+                }
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/ludos/mobile/lib/user_profile_page.dart
+++ b/ludos/mobile/lib/user_profile_page.dart
@@ -31,6 +31,7 @@ class _UserProfilePageState extends State<UserProfilePage> {
       setState(() {
         if(response.statusCode == 200){
           userData = json.decode(response.body);
+          print(userData);
         }
         else{
           userData = {};

--- a/ludos/mobile/lib/visit_user_page.dart
+++ b/ludos/mobile/lib/visit_user_page.dart
@@ -31,6 +31,7 @@ class _VisitUserPageState extends State<VisitUserPage> {
       setState(() {
         if(response.statusCode == 200){
           userData = json.decode(response.body);
+          print(userData);
         }
         else{
           userData = {};


### PR DESCRIPTION
I implemented detailed post search for mobile app. Functionality again can be tested from 'favorite' icon. For now, posts can be searched by keywords in their title or body, tags they have, and title of the game they belongs to. Unfortunately, posts can not be searched by the username of their owners because we have not an endpoint to retrieve user ids from usernames(search post endpoint currently accepts user ids). Also returned results can be filtered further whether the registered user wants only the posts he/she liked or disliked. Finally, posts could be sorted according to the criterias like createdAt and numberOfLikes in either ascending or descending order. 

Careful review is needed before merging into development branch. 