### PR TITLE
fixed thread image problem

### DIFF
--- a/ludos/frontend/src/components/ThreadComponent.js
+++ b/ludos/frontend/src/components/ThreadComponent.js
@@ -212,6 +212,15 @@ function ThreadComponent({
 
   const isOwner = currentUserId === userId;
 
+  function isValidJson(str) {
+    try {
+      JSON.parse(str);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
   return (
     <Grid style={{ display: "flex", flexDirection: "row" }}>
       <Grid
@@ -313,23 +322,27 @@ function ThreadComponent({
         </Grid>
         {contentImg && contentImg.length > 0 && (
           <Grid container spacing={2} justifyContent="center">
-            {contentImg.map((imgSrc, index) => (
-              <Grid item key={index}>
-                <img
-                  style={{
-                    maxHeight: "400px",
-                    maxWidth: "610px",
-                    borderRadius: "10px",
-                    marginBottom: "10px",
-                  }}
-                  src={JSON.parse(imgSrc).url}
-                  alt={`Image ${index + 1}`}
-                />
-              </Grid>
-            ))}
+            {contentImg.map(
+              (imgSrc, index) =>
+                imgSrc &&
+                imgSrc.length > 0 &&
+                isValidJson(imgSrc) && (
+                  <Grid item key={index}>
+                    <img
+                      style={{
+                        maxHeight: "400px",
+                        maxWidth: "610px",
+                        borderRadius: "10px",
+                        marginBottom: "10px",
+                      }}
+                      src={JSON.parse(imgSrc).url}
+                      alt={`Image ${index + 1}`}
+                    />
+                  </Grid>
+                ),
+            )}
           </Grid>
         )}
-
         <Typography
           variant="body2"
           component="div"


### PR DESCRIPTION
As indicated in #737, I noticed that some threads give error when clicked on it while testing. It was because, sometimes even if the user does not add an image to thread, it gives the empty string value ""; thus it causes a Json parsing problem. I fixed the issue by providing necessary checks. 
Now the issue is fixed an the page is seen as expected.

![image](https://github.com/bounswe/bounswe2023group7/assets/69367633/4512cfc6-c375-481b-a040-be62761e647b)
